### PR TITLE
Add --squash to cloud build

### DIFF
--- a/scripts/docker/gatkbase/build_docker_base_cloud.sh
+++ b/scripts/docker/gatkbase/build_docker_base_cloud.sh
@@ -20,7 +20,7 @@ IMAGE_VERSION=$1
 IMAGE_NAME="us.gcr.io/broad-dsde-methods/gatk-base-image-staging-area"
 DOCKER_IMAGE_TAG="${IMAGE_NAME}:gatkbase-${IMAGE_VERSION}"
 
-gcloud builds submit --tag ${DOCKER_IMAGE_TAG} --timeout=24h --machine-type n1_highcpu_32
+gcloud builds submit --config=cloudbuild.yaml --substitutions=_DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}
 
 if [ $? -ne 0 ]; then
     echo "gcloud builds submit failed"

--- a/scripts/docker/gatkbase/build_docker_base_cloud.sh
+++ b/scripts/docker/gatkbase/build_docker_base_cloud.sh
@@ -27,5 +27,5 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-echo "Successfully published image to staging area at ${DOCKER_IMAGE_TAG}"
+echo "Successfully published image to staging area at ${DOCKER_IMAGE}"
 exit 0

--- a/scripts/docker/gatkbase/build_docker_base_cloud.sh
+++ b/scripts/docker/gatkbase/build_docker_base_cloud.sh
@@ -18,9 +18,9 @@ fi
 
 IMAGE_VERSION=$1
 IMAGE_NAME="us.gcr.io/broad-dsde-methods/gatk-base-image-staging-area"
-DOCKER_IMAGE_TAG="${IMAGE_NAME}:gatkbase-${IMAGE_VERSION}"
+DOCKER_IMAGE="${IMAGE_NAME}:gatkbase-${IMAGE_VERSION}"
 
-gcloud builds submit --config=cloudbuild.yaml --substitutions=_DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}
+gcloud builds submit --config=cloudbuild.yaml --substitutions=_DOCKER_IMAGE=${DOCKER_IMAGE}
 
 if [ $? -ne 0 ]; then
     echo "gcloud builds submit failed"

--- a/scripts/docker/gatkbase/cloudbuild.yaml
+++ b/scripts/docker/gatkbase/cloudbuild.yaml
@@ -1,0 +1,25 @@
+steps:
+  # Step to enable experimental features in Docker and build with --squash
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        # Enable Docker experimental features
+        echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
+        sudo service docker restart
+        # Build and squash the Docker image
+        docker build --squash -t $$_DOCKER_IMAGE_TAG . 
+
+  # Step to push the image to a registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '$$_DOCKER_IMAGE_TAG']
+
+# Substitute variables
+substitutions:
+  _DOCKER_IMAGE_TAG: 'gcr.io/your-project-id/your-image-name:tag'
+
+# Machine type and timeout settings
+options:
+  machineType: 'N1_HIGHCPU_32'
+  timeout: '86400s'  # 24 hours in seconds

--- a/scripts/docker/gatkbase/cloudbuild.yaml
+++ b/scripts/docker/gatkbase/cloudbuild.yaml
@@ -1,25 +1,32 @@
 steps:
-  # Step to enable experimental features in Docker and build with --squash
-  - name: 'gcr.io/cloud-builders/docker'
+  # Start the Docker-in-Docker service with experimental features enabled directly
+  - id: 'setup-dind-experimental'
+    name: 'docker'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
-        # Enable Docker experimental features
-        echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
+        # Enable experimental features on Docker daemon
+        echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
         sudo service docker restart
-        # Build and squash the Docker image
-        docker build --squash -t $$_DOCKER_IMAGE_TAG . 
+        # Start a Docker-in-Docker instance
+        docker run -d --privileged --name dind-service docker:dind --experimental
+        until docker -H tcp://localhost:2375 version; do sleep 1; done
 
-  # Step to push the image to a registry
-  - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '$$_DOCKER_IMAGE_TAG']
+  # Use Docker commands with the DinD service
+  - id: 'build-and-push'
+    name: 'docker'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        export DOCKER_HOST=tcp://localhost:2375
+        docker build --squash -t ${_DOCKER_IMAGE} .
+        docker push ${_DOCKER_IMAGE}
 
-# Substitute variables
-substitutions:
-  _DOCKER_IMAGE_TAG: 'gcr.io/your-project-id/your-image-name:tag'
-
-# Machine type and timeout settings
 options:
   machineType: 'N1_HIGHCPU_32'
-  timeout: '86400s'  # 24 hours in seconds
+timeout: '1440s' # 24 hours
+
+substitutions:
+  _DOCKER_IMAGE: ''


### PR DESCRIPTION
Attempts to use Docker-in-Docker to enable experimental features and use `--squash`